### PR TITLE
support setting service buffer size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ OPTIONS:
     -d, --debug             Set log level (default: 7)
     -v, --version           Print the version and exit
     -h, --help              Print this text and exit
+    -f, --serv_buffer_size  Maximum chunk of file that can be sent at once
 ```
 
 Read the example usage on the [wiki](https://github.com/tsl0922/ttyd/wiki/Example-Usage).

--- a/man/ttyd.1
+++ b/man/ttyd.1
@@ -142,6 +142,10 @@ Cross platform: macOS, Linux, FreeBSD/OpenBSD, OpenWrt/LEDE, Windows
       SSL CA file path for client certificate verification
 
 .PP
+-f, --serv_buffer_size
+      Maximum chunk of file that can be sent at once
+
+.PP
 -d, --debug 
       Set log level (default: 7)
 

--- a/man/ttyd.man.md
+++ b/man/ttyd.man.md
@@ -98,6 +98,9 @@ ttyd 1 "September 2016" ttyd "User Manual"
   -A, --ssl-ca <ca path>
       SSL CA file path for client certificate verification
 
+  -f, --serv_buffer_size <buffer size>
+      Maximum chunk of file that can be sent at once
+
   -d, --debug <level>
       Set log level (default: 7)
 

--- a/src/server.h
+++ b/src/server.h
@@ -63,6 +63,7 @@ typedef struct {
 
 struct server {
   int client_count;        // client count
+  int serv_buffer_size;    // service buffer size
   char *prefs_json;        // client preferences
   char *credential;        // encoded basic auth credential
   char *auth_header;       // header name used for auth proxy


### PR DESCRIPTION
Pull Request Summary:

This pull request introduces a new flags: --serv_buffer_size, to support setting the websocket service buffer size.

Why need this PR ?

According to [libwebsockets](https://github.com/warmcat/libwebsockets/blob/main/include/libwebsockets/lws-context-vhost.h#L670), default buffer size is 4096 bytes. If the data being transmitted is too large, the connection might get disconnected. Adjusting the size of the buffer can fix this issue.

Test Result:
![image](https://github.com/user-attachments/assets/11dd34e2-a0f0-4070-bf78-e8e5667f2427)
